### PR TITLE
Fixed behaviour of mkSequence

### DIFF
--- a/src/IrSequence.cpp
+++ b/src/IrSequence.cpp
@@ -1,17 +1,22 @@
 #include "IrSequence.h"
 #include <string.h>
 
-IrSequence::IrSequence() : durations(NULL), length(0U), toBeFreed(false) {
+IrSequence::IrSequence() : durations(nullptr), length(0U), toBeFreed(false) {
 };
 
-IrSequence::IrSequence(const microseconds_t *durations_, size_t length_, boolean toBeFreed_)
-: durations(durations_), length(length_), toBeFreed(toBeFreed_) {
+IrSequence::IrSequence(const microseconds_t *durations, size_t length, boolean toBeFreed)
+: durations(durations), length(length), toBeFreed(toBeFreed) {
 }
 
-IrSequence::IrSequence(const IrSequence& orig) : durations(orig.durations), length(orig.length), toBeFreed(orig.toBeFreed) {
+IrSequence::IrSequence(const IrSequence& orig, boolean toBeFreed __attribute__((unused)))
+: durations(orig.durations), length(orig.length), toBeFreed(false) {
 };
 
-IrSequence::IrSequence(const IrSequence& orig, boolean toBeFreed_) : durations(orig.durations), length(orig.length), toBeFreed(toBeFreed_) {
+IrSequence::IrSequence(IrSequence& orig, boolean toBeFreed)
+: durations(orig.durations), length(orig.length), toBeFreed(toBeFreed && orig.toBeFreed) {
+    // If we're taking ownership of the underlying data, relinquish the original
+    if (this->toBeFreed)
+        orig.toBeFreed = false;
 };
 
 IrSequence::~IrSequence() {

--- a/src/IrSequence.h
+++ b/src/IrSequence.h
@@ -32,15 +32,16 @@ public:
     /**
      * Performs shallow copy.
      * @param orig original IrSequence to be cloned
+     * @param toBeFreed unused
      */
-    IrSequence(const IrSequence& orig);
+    IrSequence(const IrSequence& orig, boolean toBeFreed = false);
 
     /**
      * Performs shallow copy.
      * @param orig original IrSequence to be cloned
-     * @param toBeFreed If true, the destructor will delete the durations array.
+     * @param toBeFreed If true, will transfer the responsibility to delete the durations array.
      */
-    IrSequence(const IrSequence& orig, boolean toBeFreed);
+    IrSequence(IrSequence& orig, boolean toBeFreed = false);
 
     /**
      * Returns the length of the data.

--- a/src/IrSignal.cpp
+++ b/src/IrSignal.cpp
@@ -1,22 +1,22 @@
 #include "IrSignal.h"
 #include "IrSender.h"
 
-IrSignal::IrSignal(const IrSequence& intro_, const IrSequence& repeat_, const IrSequence& ending_,
-        frequency_t frequency_, boolean toBeFreed)
-: frequency(frequency_),intro(intro_, toBeFreed),repeat(repeat_, toBeFreed),ending(ending_, toBeFreed) {
+IrSignal::IrSignal(IrSequence& intro, IrSequence& repeat, IrSequence& ending,
+        frequency_t frequency, boolean toBeFreed)
+: frequency(frequency), intro(intro, toBeFreed), repeat(repeat, toBeFreed), ending(ending, toBeFreed) {
 }
 
-IrSignal::IrSignal(const IrSequence& intro_, const IrSequence& repeat_, const IrSequence& ending_,
-        frequency_t frequency_)
-: frequency(frequency_),intro(intro_),repeat(repeat_),ending(ending_) {
+IrSignal::IrSignal(const IrSequence& intro, const IrSequence& repeat, const IrSequence& ending,
+        frequency_t frequency, boolean toBeFreed __attribute__((unused)))
+: frequency(frequency), intro(intro, false), repeat(repeat, false), ending(ending, false) {
 }
 
-//IrSignal::IrSignal(const IrSignal& orig, boolean toBeFreed)
-//: frequency(orig.frequency),intro(orig.intro,toBeFreed),repeat(orig.repeat,toBeFreed),ending(orig.ending,toBeFreed) {
-//}
+IrSignal::IrSignal(IrSignal& orig, boolean toBeFreed)
+: IrSignal(orig.intro, orig.repeat, orig.ending, orig.frequency, toBeFreed) {
+}
 
-IrSignal::IrSignal(const IrSignal& orig)
-: frequency(orig.frequency),intro(orig.intro),repeat(orig.repeat),ending(orig.ending) {
+IrSignal::IrSignal(const IrSignal& orig, boolean toBeFreed __attribute__((unused)))
+: IrSignal(orig.intro, orig.repeat, orig.ending, orig.frequency, false) {
 }
 
 IrSignal::IrSignal(const microseconds_t *intro_, size_t introLength,
@@ -27,12 +27,6 @@ IrSignal::IrSignal(const microseconds_t *intro_, size_t introLength,
         intro(intro_, introLength, toBeFreed),
   repeat(repeat_, repeatLength, toBeFreed),
         ending(ending_, endingLength, toBeFreed) {
-}
-
-IrSignal::~IrSignal() {
-    //delete intro;
-    //delete repeat;
-    //delete ending;
 }
 
 IrSignal *IrSignal::clone() const {

--- a/src/IrSignal.h
+++ b/src/IrSignal.h
@@ -13,10 +13,9 @@ public:
     static const frequency_t defaultFrequency = 38000U;
     static const frequency_t invalidFrequency = (frequency_t) -1;
 
-    IrSignal();
-    IrSignal(const IrSignal& orig);
+    IrSignal(IrSignal& orig, boolean toBeFreed = false);
+    IrSignal(const IrSignal& orig, boolean toBeFreed = false);
 
-    virtual ~IrSignal();
     IrSignal(const microseconds_t *intro, size_t lengthIntro,
             const microseconds_t *repeat, size_t lengthRepeat,
             const microseconds_t *ending, size_t lengthEnding,
@@ -28,17 +27,17 @@ public:
             frequency_t frequency = defaultFrequency,
             boolean toBeFreed = false);
 
-    IrSignal(const IrSequence& intro, const IrSequence& repeat, const IrSequence& ending,
-            frequency_t frequency, boolean toBeFreed);
+    IrSignal(IrSequence& intro, IrSequence& repeat, IrSequence& ending,
+            frequency_t frequency = defaultFrequency, boolean toBeFreed = false);
 
     IrSignal(const IrSequence& intro, const IrSequence& repeat, const IrSequence& ending,
-            frequency_t frequency = defaultFrequency);
+            frequency_t frequency = defaultFrequency, boolean toBeFreed = false);
 
 private:
-    const frequency_t frequency;
-    const IrSequence intro;
-    const IrSequence repeat;
-    const IrSequence ending;
+    frequency_t frequency;
+    IrSequence intro;
+    IrSequence repeat;
+    IrSequence ending;
 
 public:
 

--- a/src/Pronto.cpp
+++ b/src/Pronto.cpp
@@ -53,5 +53,5 @@ IrSequence *Pronto::mkSequence(const uint16_t* data, size_t noPairs, double time
         uint32_t duration = (uint32_t) (data[i] * timebase);
         durations[i] = (microseconds_t)((duration <= MICROSECONDS_T_MAX) ? duration : MICROSECONDS_T_MAX);
     }
-    return new IrSequence(durations, 2*noPairs, false);
+    return new IrSequence(durations, 2*noPairs, true);
 }


### PR DESCRIPTION
Update to #15; mkSequence now creates an IrSequence which will free the memory allocated for it.