### PR TITLE
add STM32 arch to PinMode #ifdefs (compiles now)

### DIFF
--- a/src/PinModeStatus.h
+++ b/src/PinModeStatus.h
@@ -23,7 +23,7 @@ this program. If not, see http://www.gnu.org/licenses/.
 
 #if !defined(ARDUINO) || defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_SAMD) \
  || defined(ARDUINO_ARCH_SAM) || defined(TEENSYDUINO) || defined(ARDUINO_ARCH_ESP32) \
- || defined(ARDUINO_ARCH_ESP8266)
+ || defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_STM32)
 
 #ifdef LOW
 #undef LOW


### PR DESCRIPTION
Reported in #46 . Functionality not yet tested, but compilation passes.