### PR TITLE
Add inverted logic support to IrSender

### DIFF
--- a/src/IrSender.cpp
+++ b/src/IrSender.cpp
@@ -18,9 +18,10 @@ this program. If not, see http://www.gnu.org/licenses/.
 #include "IrSender.h"
 #include "IrSignal.h"
 
-IrSender::IrSender(pin_t pin) : sendPin(pin) {
+IrSender::IrSender(pin_t pin, bool _invert) : sendPin(pin), invert(_invert) {
     Board::getInstance()->setPinMode(pin, OUTPUT);
-    Board::getInstance()->writeLow(pin);
+    //invert = true;
+    mute();
 }
 
 IrSender::~IrSender() {
@@ -28,10 +29,17 @@ IrSender::~IrSender() {
 }
 
 void IrSender::sendIrSignal(const IrSignal& irSignal, unsigned int noSends) {
+  if (invert) {
+    if (Board::getInstance()->readDigital(13))
+      Board::getInstance()->writeLow(13);
+    else
+      Board::getInstance()->writeHigh(13);
+  }
     send(irSignal.getIntro(), irSignal.getFrequency());
     for (unsigned int i = 0; i < irSignal.noRepetitions(noSends); i++)
         send(irSignal.getRepeat(), irSignal.getFrequency());
     send(irSignal.getEnding(), irSignal.getFrequency());
+    mute();
 }
 
 void IrSender::sendWhile(const IrSignal& irSignal, bool(*trigger)()) {

--- a/src/IrSender.h
+++ b/src/IrSender.h
@@ -34,11 +34,23 @@ public:
     }
 
 protected:
-    // TODO: Rewrite for efficiency
-    inline void writeHigh() { Board::getInstance()->writeHigh(sendPin); };
-    inline void writeLow()  { Board::getInstance()->writeLow(sendPin); };
+    const bool invert; // TODO: const
 
-    IrSender(pin_t pin);
+    // TODO: Rewrite for efficiency
+    constexpr inline void writeHigh() {
+        if(invert)
+            Board::getInstance()->writeLow(sendPin);
+        else
+            Board::getInstance()->writeHigh(sendPin);
+    };
+    constexpr inline void writeLow() {
+        if (invert)
+            Board::getInstance()->writeHigh(sendPin);
+        else
+            Board::getInstance()->writeLow(sendPin);
+    };
+
+    IrSender(pin_t pin, bool invert = false);
 
     // TODO: something sensible...
     /*virtual*/ static void barfForInvalidPin(pin_t sendPin __attribute__((unused))) {};

--- a/src/IrSenderNonMod.cpp
+++ b/src/IrSenderNonMod.cpp
@@ -17,7 +17,7 @@ this program. If not, see http://www.gnu.org/licenses/.
 
 #include "IrSenderNonMod.h"
 
-IrSenderNonMod::IrSenderNonMod(pin_t pin, bool _invert) : IrSender(pin),invert(_invert) {
+IrSenderNonMod::IrSenderNonMod(pin_t pin, bool _invert) : IrSender(pin, _invert) {
 }
 
 void IrSenderNonMod::sendNonModulated(const IrSequence& irSequence, unsigned int times) {
@@ -26,17 +26,11 @@ void IrSenderNonMod::sendNonModulated(const IrSequence& irSequence, unsigned int
 }
 
 void IrSenderNonMod::sendSpace(microseconds_t time) {
-    if (invert)
-        writeHigh();
-    else
-        writeLow();
+    writeLow();
     Board::delayMicroseconds(time);
 }
 
 void IrSenderNonMod::sendMark(microseconds_t time) {
-    if (invert)
-        writeLow();
-    else
-        writeHigh();
+    writeHigh();
     Board::delayMicroseconds(time);
 }

--- a/src/IrSenderNonMod.h
+++ b/src/IrSenderNonMod.h
@@ -28,7 +28,6 @@ this program. If not, see http://www.gnu.org/licenses/.
  */
 class IrSenderNonMod : public IrSender {
 private:
-    bool const invert;
     void enable(frequency_t frequency __attribute__((unused)), dutycycle_t d __attribute__((unused)) = Board::defaultDutyCycle) {};
     void sendSpace(microseconds_t time);
     void sendMark(microseconds_t time);

--- a/src/IrSenderPwm.cpp
+++ b/src/IrSenderPwm.cpp
@@ -25,24 +25,24 @@ this program. If not, see http://www.gnu.org/licenses/.
 
 IrSenderPwm *IrSenderPwm::instance = nullptr;
 
-IrSenderPwm::IrSenderPwm(pin_t outputPin) : IrSender(outputPin) {
+IrSenderPwm::IrSenderPwm(pin_t outputPin, bool _invert) : IrSender(outputPin, _invert) {
 }
 
-IrSenderPwm *IrSenderPwm::newInstance(pin_t outputPin) {
+IrSenderPwm *IrSenderPwm::newInstance(pin_t outputPin, bool invert) {
     if (instance != nullptr)
         return nullptr;
     instance =
 #ifdef HAS_HARDWARE_PWM
-            IrSenderPwmHard::newInstance(outputPin);
+            IrSenderPwmHard::newInstance(outputPin, invert);
 #else
-            new IrSenderPwmSoftDelay(outputPin);
+            new IrSenderPwmSoftDelay(outputPin, invert);
 #endif
     return instance;
 }
 
-IrSenderPwm *IrSenderPwm::getInstance(bool create, pin_t outputPin) {
+IrSenderPwm *IrSenderPwm::getInstance(bool create, pin_t outputPin, bool invert) {
     if (instance == nullptr && create)
-        instance = newInstance(outputPin);
+        instance = newInstance(outputPin, invert);
     return instance;
 }
 

--- a/src/IrSenderPwm.h
+++ b/src/IrSenderPwm.h
@@ -32,7 +32,7 @@ private:
     static IrSenderPwm *instance;
 
 protected:
-    IrSenderPwm(pin_t sendPin);
+    IrSenderPwm(pin_t sendPin, bool invert = false);
     virtual ~IrSenderPwm() {}
 
 public:
@@ -42,13 +42,14 @@ public:
      * Returns a pointer to the instance, or nullptr if not initialized.
      * If argument true, in the latter case creates a new instance and returns it.
      */
-    static IrSenderPwm *getInstance(bool create = false, pin_t outputPin = Board::getInstance()->defaultPwmPin());
+    static IrSenderPwm *getInstance(bool create = false, pin_t outputPin = Board::getInstance()->defaultPwmPin(), bool invert = false);
+
 
     /**
      *  Creates a new instance (if not existing) and returns it.
      *  Returns nullptr if an instance already exists.
      */
-    static IrSenderPwm *newInstance(pin_t outputPin);
+    static IrSenderPwm *newInstance(pin_t outputPin, bool invert = false);
 
     static void deleteInstance();
 };

--- a/src/IrSenderPwmHard.cpp
+++ b/src/IrSenderPwmHard.cpp
@@ -23,32 +23,33 @@ this program. If not, see http://www.gnu.org/licenses/.
 
 IrSenderPwmHard *IrSenderPwmHard::instance = nullptr;
 
-IrSenderPwmHard::IrSenderPwmHard(pin_t outputPin __attribute__((unused))) : IrSenderPwm(PWM_PIN) {
+IrSenderPwmHard::IrSenderPwmHard(pin_t outputPin __attribute__((unused)), bool _invert) : IrSenderPwm(PWM_PIN, _invert) {
 }
 
 IrSenderPwmHard::~IrSenderPwmHard() {
     disable();
 }
 
-IrSenderPwmHard *IrSenderPwmHard::newInstance(pin_t outputPin) {
+IrSenderPwmHard *IrSenderPwmHard::newInstance(pin_t outputPin, bool invert) {
     if (instance != nullptr)
         return nullptr;
-    instance = new IrSenderPwmHard(outputPin);
+    instance = new IrSenderPwmHard(outputPin, invert);
     return instance;
 }
 
-IrSenderPwmHard *IrSenderPwmHard::getInstance(bool create, pin_t outputPin) {
+IrSenderPwmHard *IrSenderPwmHard::getInstance(bool create, pin_t outputPin, bool invert) {
     if (instance == nullptr && create)
-        instance = new IrSenderPwmHard(outputPin);
+        instance = new IrSenderPwmHard(outputPin, invert);
     return instance;
 }
 
 void IrSenderPwmHard::enable(frequency_t frequency, dutycycle_t dutyCycle) {
-    Board::getInstance()->enablePwm(getPin(), frequency, dutyCycle);
+    Board::getInstance()->enablePwm(getPin(), frequency, invert ? 100 - dutyCycle : dutyCycle);
 }
 
 void IrSenderPwmHard::disable() {
     Board::getInstance()->disablePwm();
+    mute();
 }
 
 void inline IrSenderPwmHard::sendMark(milliseconds_t time) {

--- a/src/IrSenderPwmHard.h
+++ b/src/IrSenderPwmHard.h
@@ -32,7 +32,7 @@ this program. If not, see http://www.gnu.org/licenses/.
  */
 class IrSenderPwmHard : public IrSenderPwm {
 public:
-    IrSenderPwmHard(pin_t outputPin = Board::getInstance()->defaultPwmPin());
+    IrSenderPwmHard(pin_t outputPin = Board::getInstance()->defaultPwmPin(), bool invert = false);
     virtual ~IrSenderPwmHard();
 
 private:
@@ -49,13 +49,13 @@ public:
      * Returns a pointer to the instance, or nullptr if not initialized.
      * If argument true, in the latter case creates a new instance and returns it.
      */
-    static IrSenderPwmHard *getInstance(bool create = false, pin_t ouputPin = Board::getInstance()->defaultPwmPin());
+    static IrSenderPwmHard *getInstance(bool create = false, pin_t outputPin = Board::getInstance()->defaultPwmPin(), bool invert = false);
 
     /**
      *  Creates a new instance (if not existing) and returns it.
      *  Returns nullptr if an instance already exists.
      */
-    static IrSenderPwmHard *newInstance(pin_t ouputPin = Board::getInstance()->defaultPwmPin());
+    static IrSenderPwmHard *newInstance(pin_t outputPin = Board::getInstance()->defaultPwmPin(), bool invert = false);
 
     static void deleteInstance() {
         delete instance;

--- a/src/IrSenderPwmSoft.cpp
+++ b/src/IrSenderPwmSoft.cpp
@@ -18,7 +18,7 @@ this program. If not, see http://www.gnu.org/licenses/.
 #include <Arduino.h>
 #include "IrSenderPwmSoft.h"
 
-IrSenderPwmSoft::IrSenderPwmSoft(pin_t outputPin) : IrSenderPwm(outputPin) {
+IrSenderPwmSoft::IrSenderPwmSoft(pin_t outputPin, bool _invert) : IrSenderPwm(outputPin, _invert) {
 }
 
 //void IrSenderPwmSoft::sendSpace(milliseconds_t time) {

--- a/src/IrSenderPwmSoft.h
+++ b/src/IrSenderPwmSoft.h
@@ -27,7 +27,7 @@ this program. If not, see http://www.gnu.org/licenses/.
  */
 class IrSenderPwmSoft : public IrSenderPwm {
 protected:
-    IrSenderPwmSoft(pin_t outputPin); // no default!
+    IrSenderPwmSoft(pin_t outputPin, bool invert = false); // no default!
     virtual ~IrSenderPwmSoft() {}
     void enable(frequency_t hz, dutycycle_t dutyCycle = Board::defaultDutyCycle);
     void sendMark(microseconds_t time);

--- a/src/IrSenderPwmSoftDelay.cpp
+++ b/src/IrSenderPwmSoftDelay.cpp
@@ -19,7 +19,7 @@ this program. If not, see http://www.gnu.org/licenses/.
 
 #include "IrSenderPwmSoftDelay.h"
 
-IrSenderPwmSoftDelay::IrSenderPwmSoftDelay(pin_t outputPin) : IrSenderPwmSoft(outputPin) {
+IrSenderPwmSoftDelay::IrSenderPwmSoftDelay(pin_t outputPin, bool _invert) : IrSenderPwmSoft(outputPin, _invert) {
 }
 
 void inline IrSenderPwmSoftDelay::sleepMicros(microseconds_t us) {

--- a/src/IrSenderPwmSoftDelay.h
+++ b/src/IrSenderPwmSoftDelay.h
@@ -27,7 +27,7 @@ this program. If not, see http://www.gnu.org/licenses/.
  */
 class IrSenderPwmSoftDelay : public IrSenderPwmSoft {
 public:
-    IrSenderPwmSoftDelay(pin_t outpitPin); // default is not meaningful!!
+    IrSenderPwmSoftDelay(pin_t outputPin, bool invert = false); // default is not meaningful!!
 
     virtual ~IrSenderPwmSoftDelay() {
     }

--- a/src/IrSenderPwmSpinWait.cpp
+++ b/src/IrSenderPwmSpinWait.cpp
@@ -18,7 +18,7 @@ this program. If not, see http://www.gnu.org/licenses/.
 #include <Arduino.h>
 #include "IrSenderPwmSpinWait.h"
 
-IrSenderPwmSpinWait::IrSenderPwmSpinWait(pin_t sendPin) : IrSenderPwmSoft(sendPin) {
+IrSenderPwmSpinWait::IrSenderPwmSpinWait(pin_t sendPin, bool invert) : IrSenderPwmSoft(sendPin, invert) {
 }
 
 void inline IrSenderPwmSpinWait::sleepMicros(microseconds_t us) {

--- a/src/IrSenderPwmSpinWait.h
+++ b/src/IrSenderPwmSpinWait.h
@@ -29,7 +29,7 @@ this program. If not, see http://www.gnu.org/licenses/.
  */
 class IrSenderPwmSpinWait : public IrSenderPwmSoft {
 public:
-    IrSenderPwmSpinWait(pin_t sendPin);
+    IrSenderPwmSpinWait(pin_t sendPin, bool invert = false);
 
     virtual ~IrSenderPwmSpinWait() {
     };


### PR DESCRIPTION
This PR adds support for inverting the logic level of the IR send pin, for scenarios where HIGH = LED off and LOW = LED on. I did this to help with https://github.com/bengtmartensson/AGirs/issues/61 which uses such an arrangement modeled after the reference circuit for the VSOP98260 chip (see also the AGirs PR: https://github.com/bengtmartensson/AGirs/pull/63 ) 

Uses a similar interface to the `invert` parameter which already existed on IrSenderNonMod but should support all sending modes, although I have only tested IrSenderPwmHard for now.

I think this PR is a pretty clean way to do things but I'm open for comments; I'm not that experienced in embedded C++ specifically so there's probably something I can improve on. There is one thing I'm not quite sure on, which I touched on more in the AGirs PR: I'm not sure whether it would be better to change the parameter order on IrSenderPwm::getInstance (and similar) so you can invert the output without knowing the default outputPin, but that might break things so I'm not sure.